### PR TITLE
Draft extensions to LRMI Learning Resource Type vocab

### DIFF
--- a/editorVocabs/dcpet-learningResourceType.ttl
+++ b/editorVocabs/dcpet-learningResourceType.ttl
@@ -1,0 +1,130 @@
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix lrmi: <http://purl.org/dcx/lrmi-vocabs/learningResourceType/> .
+@prefix dcpet: <http://purl.org/dcx/pet/learningResourceType/> .
+@prefix bibo: <http://purl.org/ontology/bibo/status/> .
+
+#=============================
+# DCPET "LEARNING RESOURCE TYPE" CONCEPT SCHEME DESCRIPTION
+#=============================
+
+dcpet: a skos:ConceptScheme ;
+    dc:title "DC-PET Learning Resource Type Vocabulary"@en-US ;
+    dc:creator "LD4PE Task Group (DCMI)"@en-US ;
+    dcterms:dateSubmitted "2015-10-08"^^xsd:date ; 
+    dc:description "A concept scheme defining the predominant genre, type or kind characterizing a learning resource"@en-US ;
+    dc:source "Extension of LRMI Learning Resource Type Vocabulary at http://purl.org/dcx/lrmi-vocabs/learningResourceType/"@en-US ;
+    adms:status bibo:draft .
+    
+#=============================
+# DCPET CONCEPTS
+#=============================
+    
+dcpet:dataset a skos:Concept ;
+    skos:prefLabel "dataset"@en-US ;
+    skosxl:prefLabel dcpet:label-dataset ; 
+    skos:definition "Visual, factual, or numerical information that comes from a sensing device, whether instrument-measured or human-observed; describes both unprocessed, \"raw\" information as well as information already organized into lists, tables, or databases."@en-US ;
+    skos:inScheme dcpet: ;
+    dcterms:source "Definition based on NSDL (https://wiki.ucar.edu/display/nsdldocs/Type)."@en-US ;
+    vs:term_status "unstable" . 
+    
+dcpet:lecture-presentation a skos:Concept ;
+    skos:prefLabel "lecture/presentation"@en-US ;
+    skosxl:prefLabel dcpet:label-lecture-presentation ; 
+    skos:definition "Audio or text record of a speech or a unit of instruction organized and delivered by an instructor for the purpose of informing a group about a topic."@en-US ;
+    skos:inScheme dcpet: ;
+    dcterms:source "Definition based on NSDL (https://wiki.ucar.edu/display/nsdldocs/Type)."@en-US ;
+    vs:term_status "unstable" .  
+    
+dcpet:lessonPlan a skos:Concept ;
+    skos:prefLabel "lesson plan"@en-US ;
+    skosxl:prefLabel dcpet:label-lessonPlan ; 
+    skos:definition "Resource to support students' learning of specific concepts, skills, or content; often includes teaching instructions, educational goals, learning objectives, and procedures"@en-US ;
+    skos:broader lrmi:lesson ;
+    skos:inScheme dcpet: ;
+    dcterms:source "Definition based on NSDL (https://wiki.ucar.edu/display/nsdldocs/Type)."@en-US ;
+    vs:term_status "unstable" .        
+    
+dcpet:screencast a skos:Concept ;
+    skos:prefLabel "screencast"@en-US ;
+    skosxl:prefLabel dcpet:label-screencast ; 
+    skos:definition "An event digitally recorded as a set of moving images for later access and presentation."@en-US ;
+    vann:usageNote "Use \"screencast\" to describe recorded video of a learning event in the form of a broadcast, lecture, learning activity, tutorial, workshop, or webinar. The recorded event may be with our without an audience present at the time of recording."@en-US ;
+    skos:inScheme dcpet: ;
+    vs:term_status "unstable" .
+    
+dcpet:syllabus a skos:Concept ;
+    skos:prefLabel "syllabus"@en-US ;
+    skosxl:prefLabel dcpet:label-syllabus ; 
+    skos:definition "Plan showing the structure of a particular course, including course description and objectives, grading policy, materials, assignments, lesson sequence, and course calendar."@en-US ;
+    skos:inScheme dcpet: ;
+    skos:broader lrmi:educatorCurriculumGuide ;
+    dcterms:source "Definition based on NSDL (https://wiki.ucar.edu/display/nsdldocs/Type)."@en-US ;
+    vs:term_status "unstable" .                    
+    
+#=============================
+# CONTEPTS INCLUDED FROM LRMI CONCEPT SCHEME FOR LEARNING RESOURCE TYPE
+# @ <http://purl.org/dcx/pet/learningResourceType/>
+#=============================
+
+lrmi:alternateAssessment skos:inScheme dcpet: .
+
+lrmi:assessmentItem skos:inScheme dcpet: .
+       
+lrmi:course skos:inScheme dcpet: .
+
+lrmi:demonstration-simulation skos:inScheme dcpet: .
+    
+lrmi:educatorCurriculumGuide skos:inScheme dcpet: .
+    
+lrmi:formativeAssessment skos:inScheme dcpet: .
+
+lrmi:images-visuals skos:inScheme dcpet: .
+    
+lrmi:interim-summativeAssessment skos:inScheme dcpet: .   
+
+lrmi:learningActivity skos:inScheme dcpet: .   
+
+lrmi:lesson skos:inScheme dcpet: .    
+
+lrmi:primarySource skos:inScheme dcpet: .         
+
+lrmi:rubricScoringGuide skos:inScheme dcpet: .
+
+lrmi:selfAssessment skos:inScheme dcpet: .
+
+lrmi:text skos:inScheme dcpet: .
+
+lrmi:textbook skos:inScheme dcpet: .      
+ 
+lrmi:unit skos:inScheme dcpet: .
+    
+#============================= 
+# EXTENDED LABELS
+#=============================    
+    
+dcpet:label-dataset a skosxl:label ;
+    skosxl:literalForm "dataset"@en-US .
+    
+dcpet:label-lecture-presentation a skosxl:label ;
+    skosxl:literalForm "lecture-presentation"@en-US .
+    
+dcpet:label-lessonPlan a skosxl:label ;
+    skosxl:literalForm "lesson plan"@en-US .    
+    
+dcpet:label-screencast a skosxl:label ;
+    skosxl:literalForm "screencast"@en-US .
+    
+dcpet:label-syllabus a skosxl:label ;
+    skosxl:literalForm "syllabus"@en-US .                 
+        
+ 


### PR DESCRIPTION
LD4PE Learning Resource Type vocabulary is primarily an extension to the similarly named LRMI vocabulary. The extension is comprised of 5 additional concepts based on Marcia & Sean’s analysis and one additional concept not in their analysis ("screencast"/"video") . Additional concepts may be added as need arises:

__Concepts are (new in bold):__
> alternative assessment
> assessment item
> course
> ---__*dataset*__
> demonstration/simulation
> educator curriculum guide
> __*syllabus*__
> formative assessment
> images/visuals
> interim/summative assessment
> learning activity
> ---__*lecture/presentation*__
> lesson
> ---__*lesson plan*__
> primary source
> rubric scoring guide
> self assessment
> __*screencast*__
> text
> text book
> unit

In the terms used in the analysis, there are several we should avoid: 
 1. __broadcast__ since it is inherently an event without necessarily being fixed in a tangible medium (recorded) by which it is later perceived, transmitted etc. Learning resources are by definition always fixed in a tangible medium. A broadcast so fixed, is a recorded audio or video. Thus the addition of "screencast" (i.e., video); and
 2. __instructional material__ since it has no settled meaning (even the NSDL definition is circular: "Resource or learning object intended to facilitate teaching or enable learning."--so defined, instructional material is a 'learning resource').