### PR TITLE
Changed to the dcpet learning resource type vocabulary

### DIFF
--- a/editorVocabs/dcpet-learningResourceType.ttl
+++ b/editorVocabs/dcpet-learningResourceType.ttl
@@ -22,7 +22,7 @@ dcpet: a skos:ConceptScheme ;
     dc:creator "LD4PE Task Group (DCMI)"@en-US ;
     dcterms:dateSubmitted "2015-10-08"^^xsd:date ; 
     dc:description "A concept scheme defining the predominant genre, type or kind characterizing a learning resource"@en-US ;
-    dc:source "Extension of LRMI Learning Resource Type Vocabulary at http://purl.org/dcx/lrmi-vocabs/learningResourceType/"@en-US ;
+    dc:source "EXTENSION of the LRMI Learning Resource Type Vocabulary at http://purl.org/dcx/lrmi-vocabs/learningResourceType/"@en-US ;
     adms:status bibo:draft .
     
 #=============================
@@ -32,18 +32,10 @@ dcpet: a skos:ConceptScheme ;
 dcpet:dataset a skos:Concept ;
     skos:prefLabel "dataset"@en-US ;
     skosxl:prefLabel dcpet:label-dataset ; 
-    skos:definition "Visual, factual, or numerical information that comes from a sensing device, whether instrument-measured or human-observed; describes both unprocessed, \"raw\" information as well as information already organized into lists, tables, or databases."@en-US ;
+    skos:definition "Visual, factual, or numerical information used in instruction that comes from a sensing device, whether instrument-measured or human-observed; describes both unprocessed, \"raw\" information as well as information already organized into lists, tables, or databases."@en-US ;
     skos:inScheme dcpet: ;
-    dcterms:source "Definition based on NSDL (https://wiki.ucar.edu/display/nsdldocs/Type)."@en-US ;
+    dcterms:source "Definition partially based on NSDL (https://wiki.ucar.edu/display/nsdldocs/Type)."@en-US ;
     vs:term_status "unstable" . 
-    
-dcpet:lecture-presentation a skos:Concept ;
-    skos:prefLabel "lecture/presentation"@en-US ;
-    skosxl:prefLabel dcpet:label-lecture-presentation ; 
-    skos:definition "Audio or text record of a speech or a unit of instruction organized and delivered by an instructor for the purpose of informing a group about a topic."@en-US ;
-    skos:inScheme dcpet: ;
-    dcterms:source "Definition based on NSDL (https://wiki.ucar.edu/display/nsdldocs/Type)."@en-US ;
-    vs:term_status "unstable" .  
     
 dcpet:lessonPlan a skos:Concept ;
     skos:prefLabel "lesson plan"@en-US ;
@@ -54,14 +46,6 @@ dcpet:lessonPlan a skos:Concept ;
     dcterms:source "Definition based on NSDL (https://wiki.ucar.edu/display/nsdldocs/Type)."@en-US ;
     vs:term_status "unstable" .        
     
-dcpet:screencast a skos:Concept ;
-    skos:prefLabel "screencast"@en-US ;
-    skosxl:prefLabel dcpet:label-screencast ; 
-    skos:definition "An event digitally recorded as a set of moving images for later access and presentation."@en-US ;
-    vann:usageNote "Use \"screencast\" to describe recorded video of a learning event in the form of a broadcast, lecture, learning activity, tutorial, workshop, or webinar. The recorded event may be with our without an audience present at the time of recording."@en-US ;
-    skos:inScheme dcpet: ;
-    vs:term_status "unstable" .
-    
 dcpet:syllabus a skos:Concept ;
     skos:prefLabel "syllabus"@en-US ;
     skosxl:prefLabel dcpet:label-syllabus ; 
@@ -69,44 +53,69 @@ dcpet:syllabus a skos:Concept ;
     skos:inScheme dcpet: ;
     skos:broader lrmi:educatorCurriculumGuide ;
     dcterms:source "Definition based on NSDL (https://wiki.ucar.edu/display/nsdldocs/Type)."@en-US ;
-    vs:term_status "unstable" .                    
+    vs:term_status "unstable" .
+    
+dcpet:technicalSpecification a skos:Concept ;
+    skos:prefLabel "technicalSpecification"@en-US ;
+    skosxl:prefLabel dcpet:label-technical-specification ; 
+    skos:definition "A technical specification describes the details of either all or specific parts of a schema, scheme, or other forms of metadata description language."@en-US ;
+    skos:scopeNote "Technical specifications include, but are not limited to the technical descriptions of metadata schemes, schema, ontologies, application profiles, and other documentation of description languages."@en-US ; 
+    skos:inScheme dcpet: ;
+    skos:broader lrmi:educatorCurriculumGuide ;
+    vs:term_status "unstable" .                         
     
 #=============================
 # CONTEPTS INCLUDED FROM LRMI CONCEPT SCHEME FOR LEARNING RESOURCE TYPE
 # @ <http://purl.org/dcx/pet/learningResourceType/>
 #=============================
 
-lrmi:alternateAssessment skos:inScheme dcpet: .
+lrmi:alternateAssessment skos:inScheme dcpet: ;
+    skos:prefLabel "alternative assessment"@en-US .
 
-lrmi:assessmentItem skos:inScheme dcpet: .
+lrmi:assessmentItem skos:inScheme dcpet: ;
+    skos:prefLabel "assessment item"@en-US .
        
-lrmi:course skos:inScheme dcpet: .
+lrmi:course skos:inScheme dcpet: ;
+    skos:prefLabel "course"@en-US .
 
-lrmi:demonstration-simulation skos:inScheme dcpet: .
+lrmi:demonstration-simulation skos:inScheme dcpet: ;
+    skos:prefLabel "demonstration/simulation"@en-US .
     
-lrmi:educatorCurriculumGuide skos:inScheme dcpet: .
+lrmi:educatorCurriculumGuide skos:inScheme dcpet: ;
+    skos:prefLabel "educator curriculum guide"@en-US .
     
-lrmi:formativeAssessment skos:inScheme dcpet: .
+lrmi:formativeAssessment skos:inScheme dcpet: ;
+    skos:prefLabel "formative assessment"@en-US .
 
-lrmi:images-visuals skos:inScheme dcpet: .
+lrmi:images-visuals skos:inScheme dcpet: ;
+    skos:prefLabel "images/visuals"@en-US .
     
-lrmi:interim-summativeAssessment skos:inScheme dcpet: .   
+lrmi:interim-summativeAssessment skos:inScheme dcpet: ;
+    skos:prefLabel "interim/summative assessment"@en-US .   
 
-lrmi:learningActivity skos:inScheme dcpet: .   
+lrmi:learningActivity skos:inScheme dcpet: ;
+    skos:prefLabel "learning activity"@en-US .    
 
-lrmi:lesson skos:inScheme dcpet: .    
+lrmi:lesson skos:inScheme dcpet: ;
+    skos:prefLabel "lesson"@en-US .    
 
-lrmi:primarySource skos:inScheme dcpet: .         
+lrmi:primarySource skos:inScheme dcpet: ;
+    skos:prefLabel "primary source"@en-US .         
 
-lrmi:rubricScoringGuide skos:inScheme dcpet: .
+lrmi:rubricScoringGuide skos:inScheme dcpet: ;
+    skos:prefLabel "rubric scoring guide"@en-US . 
 
-lrmi:selfAssessment skos:inScheme dcpet: .
+lrmi:selfAssessment skos:inScheme dcpet: ;
+    skos:prefLabel "self assessment"@en-US .
+    
+lrmi:text skos:inScheme dcpet: ;
+    skos:prefLabel "text"@en-US .
 
-lrmi:text skos:inScheme dcpet: .
-
-lrmi:textbook skos:inScheme dcpet: .      
+lrmi:textbook skos:inScheme dcpet: ;
+    skos:prefLabel "text"@en-US .     
  
-lrmi:unit skos:inScheme dcpet: .
+lrmi:unit skos:inScheme dcpet: ;
+    skos:prefLabel "unit"@en-US .
     
 #============================= 
 # EXTENDED LABELS
@@ -115,16 +124,13 @@ lrmi:unit skos:inScheme dcpet: .
 dcpet:label-dataset a skosxl:label ;
     skosxl:literalForm "dataset"@en-US .
     
-dcpet:label-lecture-presentation a skosxl:label ;
-    skosxl:literalForm "lecture-presentation"@en-US .
-    
 dcpet:label-lessonPlan a skosxl:label ;
     skosxl:literalForm "lesson plan"@en-US .    
     
-dcpet:label-screencast a skosxl:label ;
-    skosxl:literalForm "screencast"@en-US .
-    
 dcpet:label-syllabus a skosxl:label ;
-    skosxl:literalForm "syllabus"@en-US .                 
+    skosxl:literalForm "syllabus"@en-US . 
+    
+dcpet:label-technical-specification a skosxl:label ;
+    skosxl:literalForm "technical specification"@en-US .                     
         
  


### PR DESCRIPTION
This is a DCMI PET vocabulary for Learning Resource Types. It builds ont he LRMI vocabulary (through concept inclusion from that vocabulary) by adding 4 new concepts. This pull requests include: (1) removel of "screencast" and "lecture/presentation" because they are expressions of the physical form or interactivity type and not the pedagogical genre; and (2) skos:prefLabels were added to the concepts from the LRMI vocabulary that have been declared as skos:inScheme this dcpet vocabulary.